### PR TITLE
Fixes Weather on All Worlds (Please TM this first!)

### DIFF
--- a/maps/nsv_triumph/triumph_defines.dm
+++ b/maps/nsv_triumph/triumph_defines.dm
@@ -173,6 +173,11 @@
 		Z_LEVEL_LAVALAND)
 
 	lateload_single_pick = null //Nothing right now.
+	
+	planet_datums_to_make = list(/datum/planet/lavaland,
+								/datum/planet/classh,
+								/datum/planet/frozen_planet,
+								/datum/planet/gaia_planet)
 
 /datum/map/triumph/perform_map_generation()
 	return 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Does What It Says on the Tin
Apparently these planet are suppose to have weather and dynamic lighting based on time of day. Previously this was not functional because as it turns out Triumph was lasting the list in its defines that instructs the game to load them every round. Hopefully this oversight is fixed and the result won't destroy the server. Also Day Night Cycles have returned, Rejoice!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because it makes the game function like its suppose to.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Frozen Worlds, Gaia Worlds, ClassH Worlds and Lavaland now have the weather and Day/Night cycles they were intended to have.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
